### PR TITLE
Addition of identity-file argument to init-ssh!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.5
+
+* Improvements
+  * Allow setting of a specific identity file (#12).
+    Use case is to select the desired account from multiple GitHub accounts that have differing private repo membership.
+    (Thanks to @markdingram)
+
 ## 0.1.4
 
 * Bug Fixes:


### PR DESCRIPTION
This allows a specific key to be nominated for the Git SSH connection.

An example of where this can be useful:
Consider a setup where keys A & B both authenticate to GitHub but with
different access to private repositories repo-A & repo-B.

Currently the first key that successfully authenticates to Github is used for the remainder of the Git
operation. So without a means of selecting the key to use one of the
private repos will be unavailable (git error: "Repository: Not Found.")

NOTE: JSCH doesn't use the ~/.ssh/config file where this would commonly be set.
