### PR TITLE
Fixed bug when fetching new revision fails (throws exception etc)

### DIFF
--- a/src/lambdacd_git/core.clj
+++ b/src/lambdacd_git/core.clj
@@ -87,7 +87,7 @@
                              (do
                                (report-waiting-status ctx)
                                (wait-for-next-poll poll-notifications ms-between-polls kill-channel)
-                               (recur current-revisions))))))]
+                               (recur last-seen-revisions))))))]
     (clean-up-kill-switch->ch (:is-killed ctx))
     result))
 


### PR DESCRIPTION
Because the loop in "wait-for-revision-changed" would always recur with whatever revision was fetched, if the fetch fails, it recurs with the last seen revision as nil. This means that whenever a fetch fails, on the next poll the pipeline will trigger (even if there was no actual change). The recur only happens when the fetch has either failed or the revision has stayed the same, so recurring with the last seen revision should be fine and it fixes the problem.
