### PR TITLE
Add given identity-file to JSch identity repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ This changelog contains a loose collection of changes in every release. I will a
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to a "shifted" version of semantic versioning while the major version remains at 0: Minor version changes indicate breaking changes, patch version changes should not contain breaking changes.
 
+## 0.4.1
+
+### Added
+
+* The `:ssh :identity-file` configuration can now load any file as an identity file.
+
+  Prior to this change it would only load `id_rsa`, `id_dsa` and `identity` in `~/.ssh`.
+
 ## 0.4.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Certain values can be configured using LambdaCDs config-map. The following examp
                      :ssh {:use-agent                true                         ; whether to use an SSH agent
                            :known-hosts-files        ["~/.ssh/known_hosts" 
                                                       "/etc/ssh/ssh_known_hosts"] ; which known-hosts files to use for SSH connections 
-                           :identity-file            nil                          ; override the normal SSH behavior and explicitly specify a key to use when multiple possible keys are discovered by SSH (does not allow setting arbitrary identity files at the moment (see #28 for details)
+                           :identity-file            nil                          ; override the normal SSH behavior and explicitly specify a key to use
                            :strict-host-key-checking nil}}}]                      ; override the normal SSH behavior and explicitly set the StrictHostKeyChecking setting. Off by default, can be set to yes,no or ask
   (lambdacd/assemble-pipeline pipeline-structure config))
 ```

--- a/src/lambdacd_git/ssh.clj
+++ b/src/lambdacd_git/ssh.clj
@@ -2,6 +2,7 @@
   "Functions to customize handling of SSH connections"
   (:require [me.raynes.fs :as fs]
             [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
             [lambdacd-git.ssh-agent-support :as ssh-agent-support])
   (:import (org.eclipse.jgit.util FS)
            (org.eclipse.jgit.transport JschConfigSessionFactory SshSessionFactory OpenSshConfig$Host)
@@ -37,7 +38,8 @@
     (let [identity-file-full-path (str (fs/expand-home identity-file))]
       (try
         (.addIdentity jsch identity-file-full-path)
-        (catch JSchException e :ignore))
+        (catch JSchException e
+          (log/warn e "Problems adding custom identity file.")))
       (let [current (.getIdentities (.getIdentityRepository jsch))]
         (doto jsch
           (.setIdentityRepository

--- a/src/lambdacd_git/ssh.clj
+++ b/src/lambdacd_git/ssh.clj
@@ -34,7 +34,7 @@
    with permissions to a private repo."
   [identity-file]
   (fn [^JSch jsch]
-    (let [identity-file-full-path (fs/expand-home identity-file)]
+    (let [identity-file-full-path (str (fs/expand-home identity-file))]
       (try
         (.addIdentity jsch identity-file-full-path)
         (catch JSchException e :ignore))

--- a/test/lambdacd_git/end_to_end_test.clj
+++ b/test/lambdacd_git/end_to_end_test.clj
@@ -115,7 +115,9 @@
 (deftest ^:e2e-with-auth end-to-end-with-auth-test
   (testing "a complete pipeline with all features against private repositories using https and ssh"
     (doseq [repo-config [{:repo-uri (or (System/getenv "LAMBDACD_GIT_TESTREPO_SSH") "git@gitlab.com:flosell-test/testrepo.git")
-                          :git      {:ssh {:strict-host-key-checking "no"}}}
+                          :git      {:ssh {:strict-host-key-checking "no"
+                                           :identity-file "~/.ssh/id_rsa_gitlab-test"
+                                           :use-agent false}}}
                          {:repo-uri (or (System/getenv "LAMBDACD_GIT_TESTREPO_HTTPS") "https://gitlab.com/flosell-test/testrepo.git")
                           :git      {:credentials-provider (UsernamePasswordCredentialsProvider. (System/getenv "LAMBDACD_GIT_TESTREPO_USERNAME")
                                                                                                  (System/getenv "LAMBDACD_GIT_TESTREPO_PASSWORD"))}}]]


### PR DESCRIPTION
This allows any file to be set as the identity file.

Closes #28